### PR TITLE
Update enhancer.js

### DIFF
--- a/enhancer.js
+++ b/enhancer.js
@@ -23,7 +23,12 @@ define([
         require([bootUrl], function (interactive) {
             // We pass the standard context and config here, but also inject the
             // mediator so the external interactive can respond to our events.
-            interactive.boot(element, context, config, mediator);
+            interactive.boot(element, {
+                context: context,
+                config: config,
+                mediator: mediator,
+                self: bootUrl
+            });
         });
     }
 


### PR DESCRIPTION
This PR replaces the second, third and fourth arguments with a single options object, which in addition to `config`, `context` and `mediator` has a `self` property - the url of the module we're loading.

In theory this is obviously a breaking change. In practice though I don't think anyone has ever used any of the arguments other than `el`. Either way, I think we should prioritise a future-friendly design over worrying about a small number of pieces produced during the experimental phase we're just coming out of, especially since any interactives that _did_ break as a result of this change have most likely already had their traffic.
