### PR TITLE
Inject bootUrl into config as enhancerContext information

### DIFF
--- a/enhancer.js
+++ b/enhancer.js
@@ -17,13 +17,26 @@ define([
 
         var bootUrl = element.getAttribute('data-interactive');
 
+        // Poor man's clone...
+        var configCopy = {};
+        for (var k in config) {
+          if (config.hasOwnProperty(k)) {
+            configCopy[k] = config[k];
+          }
+        }
+
+        // Inject some config about the current invocation context
+        configCopy.enhancerContext = {
+          bootUrl: bootUrl
+        };
+
         // The contract here is that the interactive module MUST return an object
         // with a method called 'boot'.
 
         require([bootUrl], function (interactive) {
             // We pass the standard context and config here, but also inject the
             // mediator so the external interactive can respond to our events.
-            interactive.boot(element, context, config, mediator);
+            interactive.boot(element, context, configCopy, mediator);
         });
     }
 

--- a/enhancer.js
+++ b/enhancer.js
@@ -14,6 +14,7 @@ define([
      * @param {Mediator} mediator A pub/sub object to listen to and emit global events to the page.
      */
     function render(element, context, config, mediator) {
+        config = config || {};
 
         var bootUrl = element.getAttribute('data-interactive');
 

--- a/enhancer.js
+++ b/enhancer.js
@@ -17,6 +17,7 @@ define([
         config = config || {};
 
         var bootUrl = element.getAttribute('data-interactive');
+        var bootUrlDir = bootUrl.slice(0, bootUrl.lastIndexOf('/'));
 
         // Poor man's clone...
         var configCopy = {};
@@ -28,7 +29,8 @@ define([
 
         // Inject some config about the current invocation context
         configCopy.enhancerContext = {
-          bootUrl: bootUrl
+          bootUrl:    bootUrl,
+          bootUrlDir: bootUrlDir
         };
 
         // The contract here is that the interactive module MUST return an object


### PR DESCRIPTION
As requested by @Rich-Harris from InteractiveUS, pass the source bootUrl to the boot call by injecting it as part of the `enhancerContext` in the config.

/cc @oliverjash @rich-nguyen @andymason 
